### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/addon/globalPlugins/scanvox/__init__.py
+++ b/addon/globalPlugins/scanvox/__init__.py
@@ -18,9 +18,7 @@ import globalVars
 import sys
 from speech import speakMessage
 
-if sys.version_info.major == 3 and sys.version_info.minor == 7:
-	lib = os.path.join(os.path.dirname(__file__), "lib", "3.7")
-elif sys.version_info.major == 3 and sys.version_info.minor == 11:
+if sys.version_info.major == 3 and sys.version_info.minor == 11:
 	lib = os.path.join(os.path.dirname(__file__), "lib", "3.11")
 else:
 	log.error("Unsupported python version")

--- a/addon/globalPlugins/scanvox/__init__.py
+++ b/addon/globalPlugins/scanvox/__init__.py
@@ -20,6 +20,8 @@ from speech import speakMessage
 
 if sys.version_info.major == 3 and sys.version_info.minor == 11:
 	lib = os.path.join(os.path.dirname(__file__), "lib", "3.11")
+elif sys.version_info.major == 3 and sys.version_info.minor == 13:
+	lib = os.path.join(os.path.dirname(__file__), "lib", "3.13")
 else:
 	log.error("Unsupported python version")
 


### PR DESCRIPTION
Remove support for Python 3.7, which means that the minimum version of NVDA is now 2024.1.